### PR TITLE
Feature!/uv

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2024 NTT DATA, Inc.
+Copyright 2025 NTT DATA, Inc.
 
 Software, source files, and snippets are licensed under the Apache 2.0 license.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Launch Common Automation Framework - Python Module Component
 
-This repo holds the component for Python modules within the Launch Common Automation Framework (LCAF).
+This repo holds the component for Python modules utilizing [uv](https://docs.astral.sh/uv/) within the Launch Common Automation Framework (LCAF).
 
 It contains the following:
 

--- a/linkfiles/.pre-commit-config.yaml
+++ b/linkfiles/.pre-commit-config.yaml
@@ -1,37 +1,62 @@
+default_install_hook_types:
+  - pre-commit
+  - post-checkout
+  - post-merge
+  - post-rewrite
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
       - id: trailing-whitespace
+        stages:
+          - pre-commit
       - id: check-case-conflict
+        stages:
+          - pre-commit
       - id: check-executables-have-shebangs
+        stages:
+          - pre-commit
       - id: check-json
+        stages:
+          - pre-commit
       - id: check-merge-conflict
+        stages:
+          - pre-commit
       - id: check-shebang-scripts-are-executable
+        stages:
+          - pre-commit
       - id: check-yaml
         args:
           - --allow-multiple-documents
+        stages:
+          - pre-commit
       - id: end-of-file-fixer
+        stages:
+          - pre-commit
       - id: mixed-line-ending
         args:
           - --fix=auto
-  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.4.0
-    hooks:
-      - id: commitlint
-        stages: [commit-msg]
-        additional_dependencies: ["@commitlint/config-conventional"]
+        stages:
+          - pre-commit
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.4.0
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
         exclude: package.lock.json
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+        stages:
+          - pre-commit
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.5.18
     hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black
+      # Update the uv lockfile
+      - id: uv-lock
+        stages:
+          - pre-commit
+      - id: uv-sync
+        stages:
+          - pre-commit
+          - post-checkout
+          - post-merge
+          - post-rewrite

--- a/linkfiles/.secrets.baseline
+++ b/linkfiles/.secrets.baseline
@@ -1,0 +1,112 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2023-05-03T20:14:44Z"
+}

--- a/tasks/python/Makefile
+++ b/tasks/python/Makefile
@@ -3,7 +3,7 @@ python/venv:
 	uv venv
 
 .PHONY: python/test
-python/test:
+test::
 	pytest
 
 .PHONY: python/build

--- a/tasks/python/Makefile
+++ b/tasks/python/Makefile
@@ -15,5 +15,5 @@ test::
 	pytest
 
 .PHONY: coverage
-coverage:: pytest
+coverage:: test
 	open -a "Google Chrome" htmlcov/index.html

--- a/tasks/python/Makefile
+++ b/tasks/python/Makefile
@@ -2,10 +2,12 @@
 python/venv:
 	uv venv
 
-.PHONY: python/test
-test::
-	pytest
-
 .PHONY: python/build
 python/build:
 	uv build
+
+lint::
+	uvx ruff check
+
+test::
+	pytest

--- a/tasks/python/Makefile
+++ b/tasks/python/Makefile
@@ -1,21 +1,19 @@
-.SILENT
-
 .PHONY: python/venv
 python/venv:
-	uv venv
+	@uv venv
 
 .PHONY: python/build
 python/build:
-	uv build
+	@uv build
 
 .PHONY: lint
 lint::
-	uvx ruff check
+	@uvx ruff check
 
 .PHONY: test
 test::
-	pytest
+	@pytest
 
 .PHONY: coverage
 coverage:: test
-	open -a "Google Chrome" htmlcov/index.html
+	@open -a "Google Chrome" htmlcov/index.html

--- a/tasks/python/Makefile
+++ b/tasks/python/Makefile
@@ -12,7 +12,7 @@ lint::
 
 .PHONY: test
 test::
-	@pytest
+	@uv run pytest
 
 .PHONY: coverage
 coverage:: test

--- a/tasks/python/Makefile
+++ b/tasks/python/Makefile
@@ -6,8 +6,14 @@ python/venv:
 python/build:
 	uv build
 
+.PHONY: lint
 lint::
 	uvx ruff check
 
+.PHONY: test
 test::
 	pytest
+
+.PHONY: coverage
+coverage:: pytest
+	open -a "Google Chrome" htmlcov/index.html

--- a/tasks/python/Makefile
+++ b/tasks/python/Makefile
@@ -1,3 +1,5 @@
+.SILENT
+
 .PHONY: python/venv
 python/venv:
 	uv venv

--- a/tasks/python/Makefile
+++ b/tasks/python/Makefile
@@ -1,45 +1,11 @@
 .PHONY: python/venv
-python/venv: .venv/touchfile
-
-.venv/touchfile:
-	test -d .venv || python3 -m venv .venv
-	source .venv/bin/activate; pip install -q -r requirements.txt || pip install -q .
-	touch .venv/touchfile
-
-.PHONY: python/test/requirements
-python/test/requirements: python/venv
-	@if [ -f requirements.txt ]; then \
-		echo "Installing from requirements.txt"; \
-		pip install -q -r requirements.txt; \
-	fi
-	@if [ -f requirements_test.txt ]; then \
-		echo "Installing from requirements_test.txt"; \
-		pip install -q -r requirements_test.txt; \
-	fi
+python/venv:
+	uv venv
 
 .PHONY: python/test
-python/test: python/test/requirements python/test/unit
+python/test:
+	pytest
 
-.PHONY: python/test/full
-test/full: python/test/unit python/test/integration
-
-.PHONY: python/test/unit
-python/test/unit: python/test/requirements
-	@if [ -d test/unit ]; then \
-		echo "Running unit tests"; \
-		pytest test/unit -ra -vv; \
-	fi
-
-.PHONY: python/test/integration
-python/test/integration: python/test/requirements
-	@-$(MAKE) python/test/integration/setup;
-	@if [ -d test/integration ]; then \
-		echo "Running integration tests"; \
-		pytest test/integration --tb=no -v; \
-	fi
-	@-$(MAKE) python/test/integration/teardown;
-
-.PHONY: python/clean
-python/clean:
-	@rm -fr .pytest_cache
-	@rm -f .venv/touchfile
+.PHONY: python/build
+python/build:
+	uv build


### PR DESCRIPTION
Breaking change: drops direct `pip` usage in favor of `uv`, a modern package manager for Python.

https://docs.astral.sh/uv/

Among many other improvements over `pip`, `uv` is _significantly_ faster, manages entire Python installations (not just packages!), handles building and publishing packages to PyPI, and still allows for the older `pip` interactions if one desires. `uvx` gives us ephemeral Python environments that can be used to run one-offs, or even invoke our launch-cli commands at a specific version without having to juggle the dependencies on your machine.

Updates have been made to the `Makefile` to allow usage of `make lint` and `make test` targets that bind to `ruff` (think `black` + `isort`) and `pytest` respectively. In addition to our standard commit hooks and linting on commit, I added commit hooks to synchronize one's local environment when moving between branches.

This will be released as 2.0.0. I'll be bumping versions in `launch-common-automation-framework` to point at this new tag, but we'll leave `launch-cli` on the older module for now -- some work will need to be done to update that repository to utilize the new tooling.