### PR TITLE
configure target should run pytest and ignore errors first

### DIFF
--- a/tasks/python/Makefile
+++ b/tasks/python/Makefile
@@ -15,5 +15,6 @@ test::
 	@uv run pytest
 
 .PHONY: coverage
-coverage:: test
+coverage::
+	@-uv run pytest
 	@open -a "Google Chrome" htmlcov/index.html


### PR DESCRIPTION
We need slightly different behavior between `make test` and the pytest run performed by `make coverage`

`make test` should bubble failures back up to the shell; if not all tests are passing or the coverage is insufficient, it shouldn't be exiting with a successful code.

However, `make coverage` just requires that pytest be run and coverage files are output, it doesn't necessarily hinge on the successful run of all tests, and definitely shouldn't only succeed if coverage is sufficient.

This change will allow `make test` to correctly report failures, and allow `make configure` to run pytest without failures blocking subsequent actions.

I will probably just move the tag on this release rather than cutting a new version -- nothing is using this yet anyway.